### PR TITLE
feat: 新增基于文本格式的 ReAct Agent 示例

### DIFF
--- a/examples/react_agent/main.go
+++ b/examples/react_agent/main.go
@@ -81,9 +81,15 @@ func main() {
 		case reactagent.AgentChunkTypeText:
 			// 立即显示增量文本
 			fmt.Print(chunk.TextDelta)
+
+		case reactagent.AgentChunkTypeReasoning:
+			// 打印推理内容
+			fmt.Print(chunk.ThoughtContent)
+
 		case reactagent.AgentChunkTypeToolStart:
 			// 显示工具正在执行的指示
 			fmt.Printf("\n[执行工具: %s %s]\n", chunk.ToolName, chunk.ToolArguments)
+
 		case reactagent.AgentChunkTypeToolEnd:
 			// 显示工具执行完成的指示
 			if chunk.Error != "" {
@@ -91,9 +97,11 @@ func main() {
 			} else {
 				fmt.Printf("\n[工具执行完成: %s]\n", chunk.ToolName)
 			}
+
 		case reactagent.AgentChunkTypeError:
 			// 显示错误
 			fmt.Printf("\n错误: %s\n", chunk.Error)
+
 		case reactagent.AgentChunkTypeFinish, reactagent.AgentChunkTypeMaxIter:
 			// 显示结束信息
 			if chunk.Error != "" {

--- a/examples/text_agent/README.md
+++ b/examples/text_agent/README.md
@@ -1,0 +1,171 @@
+# 基于文本格式的ReAct Agent示例
+
+这个示例展示了如何使用不依赖于function call能力的ReAct Agent实现。适用于那些不支持工具调用API的模型，通过解析模型生成的文本格式来执行工具调用。
+
+## 功能特点
+
+- 支持不同的文本格式解析器，可以自定义模型输出的格式
+- 与现有的ReAct Agent共享相同的工具生态系统
+- 提供流式输出支持
+- 可配置的最大迭代次数和系统提示
+- 特别适用于不支持function calling的模型（如deepseek-reasoner）
+
+## 可用的文本格式解析器
+
+该实现提供了几种常见的文本格式解析器：
+
+1. `JSONFormatParser` - 解析JSON格式的工具调用，例如：
+   ```json
+   {"action": "fetch", "action_input": {"url": "https://example.com"}}
+   ```
+
+2. `MarkdownFormatParser` - 解析Markdown代码块格式的工具调用，例如：
+   ```
+   ```fetch
+   {"url": "https://example.com"}
+   ```
+   ```
+
+3. `PredefinedPatternParser` - 解析自定义模式的工具调用，例如：
+   ```
+   工具: fetch
+   参数: {"url": "https://example.com"}
+   ```
+
+4. `GuiAgentFormatParser` - 解析类似GUI Agent格式的工具调用，例如：
+   ```
+   Thought: 我需要获取天气信息
+   Action: fetch(url="https://weather.example.com")
+   ```
+
+## 使用方法
+
+1. 选择适合的LLM适配器（支持或不支持function calling的模型）
+2. 创建一个文本格式解析器实例
+3. 构建TextBasedAgent，提供解析器、LLM适配器和工具注册表
+4. 运行Agent并处理输出
+
+## 特别说明：适配不支持function calling的模型
+
+对于不支持function calling的模型（如本示例中使用的deepseek-reasoner），需要使用`NoToolChatAdapter`来避免向模型发送工具调用信息。
+
+示例代码：
+
+```go
+// 创建模型
+chatModel, err := deepseek.NewChatModel(ctx, &deepseek.ChatModelConfig{
+    APIKey:      apiKey,
+    Model:       "deepseek-reasoner", // 不支持 function call
+    MaxTokens:   4096,
+    Temperature: 0.7,
+})
+
+// 使用NoToolChatAdapter适配器
+llmAdapter, err := eino.NewNoToolChatAdapter(ctx, chatModel)
+
+// 选择一个解析器
+parser := &reactagent.MarkdownFormatParser{}
+
+// 构建基于文本的ReAct Agent
+agent, err := agentBuilder.
+    WithLLMAdapter(llmAdapter).
+    WithToolRegistry(registry).
+    WithSystemPrompt(systemPrompt).
+    WithTextFormatParser(parser).
+    Build()
+```
+
+## 提示词设计
+
+为了让模型返回符合特定格式的内容，需要在系统提示中明确指定输出格式，并且最好提供具体的例子。例如：
+
+```
+对于所有任务，你必须使用以下Markdown代码块格式来调用工具：
+
+首先，分析问题：
+我需要解决的问题是...
+
+然后，必须使用Markdown代码块来调用工具，格式如下：
+```tool_name
+{"参数1": "值1", "参数2": "值2"}
+```
+
+例如，要获取某网站的内容，应该这样调用：
+```fetch
+{"url": "https://example.com"}
+```
+```
+
+## 常见问题解决
+
+1. **模型不按预期格式输出**：
+   - 提高temperature参数（如设置为0.7）以增加输出多样性
+   - 修改系统提示，添加更详细的格式示例和更明确的指令
+   - 在用户输入中明确要求使用特定格式
+
+2. **返回"不支持function calling"错误**：
+   - 确保使用`NoToolChatAdapter`而不是标准的`ChatAdapter`
+   - 这表明API请求中仍包含了function calling信息
+
+3. **无法解析工具调用**：
+   - 检查解析器是否与模型输出格式匹配
+   - 打印并检查模型原始输出，看看格式是否正确
+
+## 自定义解析器
+
+你可以通过实现`TextFormatParser`接口来创建自定义的文本格式解析器：
+
+```go
+type TextFormatParser interface {
+    // ParseToolCalls 从文本中解析出工具调用请求
+    // 返回解析出的工具调用列表和解析后的剩余文本
+    ParseToolCalls(text string) ([]llminterface.ToolCall, string)
+}
+``` 
+
+## 如何运行示例
+
+1. 设置环境变量 `DEEPSEEK_API_KEY` 为你的DeepSeek API密钥
+2. 执行命令：
+   ```bash
+   go run examples/text_agent/main.go
+   ```
+
+## 实现架构与流程
+
+### 架构解析
+
+我们的实现由两个关键部分组成：
+
+1. **NoToolChatAdapter**: 
+   - 专门为不支持function calling的模型设计的适配器
+   - 使用普通的ChatModel而非ToolCallingChatModel
+   - 在API请求中不包含任何工具定义和工具调用数据结构
+   - 仅发送纯文本消息给LLM模型
+
+2. **文本格式解析器**:
+   - 实现TextFormatParser接口
+   - 从LLM返回的纯文本输出中提取工具调用指令
+   - 支持多种格式（JSON、Markdown、自定义格式等）
+
+### 执行流程
+
+1. **初始化**:
+   - 创建工具注册表并注册工具（如fetch工具）
+   - 创建纯聊天模型（非工具调用模型）
+   - 创建NoToolChatAdapter适配器（不发送工具信息）
+   - 创建文本格式解析器（如MarkdownFormatParser）
+   - 构建TextBasedAgent
+
+2. **执行过程**:
+   - 向模型发送系统提示和用户输入
+   - 模型以纯文本形式返回包含工具调用格式的输出
+   - 文本解析器从输出中提取工具调用
+   - 执行工具调用并将结果返回给模型
+   - 重复以上步骤直到任务完成或达到最大迭代次数
+
+3. **与标准Agent的区别**:
+   - 标准Agent: 通过模型API的特殊数据结构传递工具调用
+   - 文本Agent: 通过分析模型生成的文本内容解析工具调用
+
+这种实现方式的优势在于它可以使用几乎任何LLM模型构建ReAct Agent，即使该模型不支持官方的function calling API。只要模型能够理解指令并按照特定格式生成输出，我们就能通过文本解析的方式实现Agent功能。 

--- a/examples/text_agent/main.go
+++ b/examples/text_agent/main.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cloudwego/eino-ext/components/model/deepseek"
+
+	"github.com/m4n5ter/another-me/pkg/i18n"
+	"github.com/m4n5ter/another-me/pkg/llminterface/eino"
+	"github.com/m4n5ter/another-me/pkg/reactagent"
+	"github.com/m4n5ter/another-me/pkg/toolcore"
+	"github.com/m4n5ter/another-me/pkg/tools/fetchtool"
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// 使用全局i18n服务
+	i18nService := i18n.GlobalManager
+
+	// 创建上下文
+	ctx := context.Background()
+
+	// 创建工具注册表并注册工具
+	registry := toolcore.NewRegistry()
+
+	// 注册fetch工具
+	fetchTool := fetchtool.NewFetchTool(i18nService)
+	err := registry.Register(ctx, fetchTool)
+	if err != nil {
+		logger.Error("Failed to register fetch tool", "error", err)
+		os.Exit(1)
+	}
+	logger.Info("已注册工具", "toolName", "fetch")
+
+	// 从环境变量获取API密钥
+	apiKey := os.Getenv("DEEPSEEK_API_KEY")
+	if apiKey == "" {
+		logger.Error("API Key is not set")
+		os.Exit(1)
+	}
+
+	chatModel, err := deepseek.NewChatModel(ctx, &deepseek.ChatModelConfig{
+		APIKey:      apiKey,
+		Model:       "deepseek-reasoner", // 不支持 function call
+		MaxTokens:   4096,
+		Temperature: 0.7,
+	})
+	if err != nil {
+		logger.Error("Failed to create deepseek model", "error", err)
+		os.Exit(1)
+	}
+
+	llmAdapter, err := eino.NewNoToolChatAdapter(ctx, chatModel)
+	if err != nil {
+		logger.Error("Failed to create no-tool LLM adapter", "error", err)
+		os.Exit(1)
+	}
+
+	systemPrompt := `你是一个强大的助手，需要使用工具来帮助用户完成任务。
+
+对于所有任务，你必须使用以下Markdown代码块格式来调用工具：
+
+首先，分析问题：
+我需要解决的问题是...
+
+然后，必须使用Markdown代码块来调用工具，格式如下：
+` + "```" + `工具名称
+{"参数1": "值1", "参数2": "值2"}
+` + "```" + `
+
+可用的工具有：
+1. fetch - 从网络获取内容
+   参数: 
+   - url: 要获取的URL (必需参数，字符串格式)
+   - start_index: 返回内容的起始索引 (可选参数，数字格式，默认0)
+   - max_length: 最大返回字符数 (可选参数，数字格式，默认10000)
+   - raw: 是否返回原始内容 (可选参数，布尔值格式，默认false)
+   - ignore_robots_txt: 是否忽略 robots.txt 限制 (可选参数，布尔值格式，默认false)
+   - user_agent: 自定义 User-Agent 字符串 (可选参数，字符串格式)
+   - proxy_url: 代理URL (可选参数，字符串格式，例如 socks5://127.0.0.1:55535)
+   - is_manual_request: 是否由用户操作手动触发 (可选参数，布尔值格式，默认false)
+
+例如，要获取某网站的内容，应该这样调用：
+
+我需要获取网站内容，应该使用fetch工具。
+
+` + "```" + `fetch
+{"url": "https://example.com", "ignore_robots_txt": true}
+` + "```" + `
+
+你必须严格按照这个Markdown代码块格式输出工具调用，否则系统将无法执行并处理你的请求。必须记住所有的工具调用都不是来自用户，而是由你通过工具调用操控系统来执行的。
+`
+	parser := &reactagent.MarkdownFormatParser{}
+	agentBuilder := reactagent.NewTextBasedAgentBuilder()
+	agent, err := agentBuilder.
+		WithLLMAdapter(llmAdapter).
+		WithToolRegistry(registry).
+		WithLogger(logger).
+		WithSystemPrompt(systemPrompt).
+		WithTextFormatParser(parser).
+		WithMaxIterations(10).
+		Build()
+	if err != nil {
+		logger.Error("Failed to create agent", "error", err)
+		os.Exit(1)
+	}
+
+	userInput := `获取百度 (https://www.baidu.com) 的首页内容并总结。必须无视 robots.txt 的限制。`
+	conversationID := fmt.Sprintf("text-agent-%d", time.Now().Unix())
+
+	fmt.Println("开始执行任务:", userInput)
+	outputChan, err := agent.Run(ctx, userInput, conversationID)
+	if err != nil {
+		logger.Error("Failed to run agent", "error", err)
+		os.Exit(1)
+	}
+
+	// 处理Agent输出
+	var outputBuffer strings.Builder
+	var thoughtContent string
+	allText := ""
+
+	for chunk := range outputChan {
+		switch chunk.Type {
+		case reactagent.AgentChunkTypeText:
+			// 流式打印文本
+			fmt.Print(chunk.TextDelta)
+			outputBuffer.WriteString(chunk.TextDelta)
+			// 累积所有文本
+			allText += chunk.TextDelta
+
+		case reactagent.AgentChunkTypeReasoning:
+			// 打印推理内容
+			fmt.Print(chunk.ThoughtContent)
+
+		case reactagent.AgentChunkTypeThought:
+			thoughtContent = chunk.ThoughtContent
+			logger.Debug("LLM思考内容", "content", chunk.ThoughtContent)
+			// 打印完整的思考内容以便调试
+			fmt.Printf("\n\n=== 模型原始输出 ===\n%s\n====================\n\n", chunk.ThoughtContent)
+
+		case reactagent.AgentChunkTypeToolStart:
+			logger.Info("执行工具开始", "toolName", chunk.ToolName, "arguments", chunk.ToolArguments)
+			fmt.Printf("\n[执行工具: %s %s]\n", chunk.ToolName, chunk.ToolArguments)
+
+		case reactagent.AgentChunkTypeToolEnd:
+			if chunk.Error != "" {
+				logger.Error("工具执行失败", "toolName", chunk.ToolName, "error", chunk.Error)
+				fmt.Printf("\n[工具执行失败: %s - %s]\n", chunk.ToolName, chunk.Error)
+			} else {
+				logger.Info("工具执行完成", "toolName", chunk.ToolName, "resultLength", len(chunk.ToolResult))
+				fmt.Printf("\n[工具执行完成: %s]\n", chunk.ToolName)
+				// 打印工具调用结果前1000个字符以便调试
+				resultPreview := chunk.ToolResult
+				if len(resultPreview) > 1000 {
+					resultPreview = resultPreview[:1000] + "... (内容截断)"
+				}
+				fmt.Printf("\n[工具结果预览]\n%s\n", resultPreview)
+			}
+
+		case reactagent.AgentChunkTypeFinish:
+			logger.Info("Agent完成", "finalResponse", chunk.FinalResponse)
+			// 如果没有解析到工具调用且完成，打印原始输出以便调试
+			if thoughtContent != "" && !strings.Contains(thoughtContent, "```fetch") {
+				logger.Warn("未检测到工具调用格式", "content", thoughtContent)
+			}
+
+		case reactagent.AgentChunkTypeError:
+			logger.Error("Agent执行错误", "error", chunk.Error)
+			fmt.Printf("\n错误: %s\n", chunk.Error)
+
+		case reactagent.AgentChunkTypeMaxIter:
+			logger.Warn("达到最大迭代次数", "error", chunk.Error)
+		}
+
+		if chunk.IsLast {
+			logger.Info("Agent执行结束")
+			break
+		}
+	}
+
+	// 打印最终结果
+	fmt.Println("\n\n============ 最终输出 ============")
+	fmt.Println(outputBuffer.String())
+}

--- a/internal/gui_agent/parse.go
+++ b/internal/gui_agent/parse.go
@@ -22,14 +22,14 @@ func ParseActionOutput(outputText string) (string, error) {
 	}
 
 	// 提取Thought部分
-	thoughtRegex := regexp.MustCompile(`(?s)Thought:(.*?)\nAction:`)
+	thoughtRegex := regexp.MustCompile(`(?s)Thought:(.*?)\nAction:`) // Satety: const pattern
 	thoughtMatches := thoughtRegex.FindStringSubmatch(outputText)
 	if len(thoughtMatches) > 1 {
 		result.Thought = strings.TrimSpace(thoughtMatches[1])
 	}
 
 	// 提取Action部分
-	actionRegex := regexp.MustCompile(`(?s)Action:(.*?)(?:\n|$)`)
+	actionRegex := regexp.MustCompile(`(?s)Action:(.*?)(?:\n|$)`) // Satety: const pattern
 	actionMatches := actionRegex.FindStringSubmatch(outputText)
 	if len(actionMatches) > 1 { //nolint:nestif // ParseActionOutput 的逻辑是必要的
 		actionText := strings.TrimSpace(actionMatches[1])

--- a/pkg/llminterface/dto.go
+++ b/pkg/llminterface/dto.go
@@ -88,6 +88,7 @@ type ChatOutputChunk struct {
 	// 对于多模态输出或需要发送结构化数据（如工具调用信息，如果以内容形式表示）时，
 	// 这里可以包含多个或不同类型的 ContentPart。
 	ContentParts []ContentPart  `json:"content_parts,omitempty"`
+	Reasoning    Option[string] `json:"reasoning,omitempty"`     // 推理内容
 	Error        error          `json:"-"`                       // 在处理此数据块或终止流时发生的错误。如果非nil，则流在此处被视为失败。
 	FinishReason Option[string] `json:"finish_reason,omitempty"` // 流结束的原因 (例如 "stop", "length")。通常在指示流终止的最后一个块中出现。
 }

--- a/pkg/llminterface/eino/eino.go
+++ b/pkg/llminterface/eino/eino.go
@@ -74,49 +74,11 @@ func (a *ChatAdapter) Chat(ctx context.Context, input llminterface.ChatInput) (<
 			}
 
 			chunk := llminterface.ChatOutputChunk{}
-			var parts []llminterface.ContentPart
 
-			// 1. 处理普通内容 (Content 和 MultiContent)
-			if msg.Content != "" {
-				parts = append(parts, llminterface.ContentPart{
-					Type: llminterface.PartTypeText,
-					Text: msg.Content,
-				})
-			} else if msg.MultiContent != nil {
-				for _, mcPart := range msg.MultiContent {
-					switch mcPart.Type {
-					case schema.ChatMessagePartTypeText:
-						parts = append(parts, llminterface.ContentPart{
-							Type: llminterface.PartTypeText,
-							Text: mcPart.Text,
-						})
-					case schema.ChatMessagePartTypeImageURL:
-						if mcPart.ImageURL != nil {
-							imageDetail := llminterface.ImageDetailAuto // Default
-							if mcPart.ImageURL.Detail != "" {
-								switch mcPart.ImageURL.Detail {
-								case schema.ImageURLDetailLow:
-									imageDetail = llminterface.ImageDetailLow
-								case schema.ImageURLDetailHigh:
-									imageDetail = llminterface.ImageDetailHigh
-								case schema.ImageURLDetailAuto:
-									imageDetail = llminterface.ImageDetailAuto
-								default:
-									slog.Warn("Unknown eino ImageURLDetail, defaulting to auto", "detail", mcPart.ImageURL.Detail)
-								}
-							}
-							parts = append(parts, llminterface.ContentPart{
-								Type: llminterface.PartTypeImageURL,
-								ImageURL: Some(llminterface.ImageURLContent{
-									URL:    mcPart.ImageURL.URL,
-									Detail: Some(imageDetail),
-								}),
-							})
-						}
-					default:
-						slog.Warn("Unsupported eino.ChatMessagePartType in MultiContent.", "type", mcPart.Type)
-					}
-				}
+			// 1. 处理基本内容部分
+			parts, reasoningContent := ProcessEinoMessageToContentParts(msg)
+			if reasoningContent != "" {
+				chunk.Reasoning = Some(reasoningContent)
 			}
 
 			// 2. 处理工具调用请求 (ToolCalls)
@@ -138,7 +100,7 @@ func (a *ChatAdapter) Chat(ctx context.Context, input llminterface.ChatInput) (<
 			}
 
 			// 只有当有实际内容或工具调用时才发送 chunk
-			if len(parts) > 0 {
+			if len(parts) > 0 || chunk.Reasoning.IsSome() {
 				chunk.ContentParts = parts
 				chunk.FinishReason = finishReason
 				outputChan <- chunk

--- a/pkg/llminterface/eino/no_tool_adapter.go
+++ b/pkg/llminterface/eino/no_tool_adapter.go
@@ -1,0 +1,95 @@
+package eino
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/cloudwego/eino/components/model"
+
+	"github.com/m4n5ter/another-me/pkg/llminterface"
+	. "github.com/m4n5ter/another-me/pkg/option"
+	"github.com/m4n5ter/another-me/pkg/toolcore"
+)
+
+// NoToolChatAdapter 是 eino 的不发送工具信息的适配器实现
+// 适用于不支持工具调用的模型，如 deepseek-reasoner
+type NoToolChatAdapter struct {
+	// einoModel 持有原始的无工具模型
+	einoModel model.BaseChatModel
+}
+
+// NewNoToolChatAdapter 创建一个新的不使用工具调用的eino适配器实例
+func NewNoToolChatAdapter(ctx context.Context, initialModel model.BaseChatModel) (*NoToolChatAdapter, error) {
+	adapter := &NoToolChatAdapter{
+		einoModel: initialModel,
+	}
+	return adapter, nil
+}
+
+var _ llminterface.ChatAdapter = (*NoToolChatAdapter)(nil)
+
+// GetFrameworkName 返回此适配器实例所适配的底层框架的名称
+func (a *NoToolChatAdapter) GetFrameworkName() string {
+	return "eino-no-tool"
+}
+
+// Chat 方法用于向不支持工具调用的LLM发起一次对话交互
+func (a *NoToolChatAdapter) Chat(ctx context.Context, input llminterface.ChatInput) (<-chan llminterface.ChatOutputChunk, error) {
+	// 将输入转换为eino消息格式，但不包含工具信息
+	einoMsgs := ChatInputToEinoMsgs(input)
+
+	// 使用模型进行流式对话
+	streamReader, err := a.einoModel.Stream(ctx, einoMsgs)
+	if err != nil {
+		return nil, fmt.Errorf("eino model stream error: %w", err)
+	}
+
+	outputChan := make(chan llminterface.ChatOutputChunk)
+
+	go func() {
+		defer close(outputChan)
+
+		finishReason := None[string]()
+		for {
+			msg, err := streamReader.Recv()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return
+				}
+				outputChan <- llminterface.ChatOutputChunk{Error: err}
+				return
+			}
+
+			if msg.ResponseMeta != nil && msg.ResponseMeta.FinishReason != "" {
+				finishReason = Some(msg.ResponseMeta.FinishReason)
+			}
+
+			chunk := llminterface.ChatOutputChunk{}
+
+			// 处理Eino消息
+			parts, reasoningContent := ProcessEinoMessageToContentParts(msg)
+			if reasoningContent != "" {
+				chunk.Reasoning = Some(reasoningContent)
+			}
+
+			// 只有当有实际内容时才发送 chunk
+			if len(parts) > 0 || chunk.Reasoning.IsSome() {
+				chunk.ContentParts = parts
+				chunk.FinishReason = finishReason
+				outputChan <- chunk
+			}
+		}
+	}()
+
+	return outputChan, nil
+}
+
+// RegisterTools 实现接口，但不执行任何操作
+// 因为这个适配器专门用于不支持工具调用的模型
+func (a *NoToolChatAdapter) RegisterTools(ctx context.Context, registry *toolcore.Registry) error {
+	slog.Info("NoToolChatAdapter: ignoring tool registration as this adapter is for models without tool support")
+	return nil
+}

--- a/pkg/llminterface/eino/response_processor.go
+++ b/pkg/llminterface/eino/response_processor.go
@@ -1,0 +1,82 @@
+package eino
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/cloudwego/eino/schema"
+
+	"github.com/m4n5ter/another-me/pkg/llminterface"
+	. "github.com/m4n5ter/another-me/pkg/option"
+)
+
+// ProcessEinoMessageToContentParts 将eino消息转换为内容部分数组，并返回推理内容
+func ProcessEinoMessageToContentParts(msg *schema.Message) ([]llminterface.ContentPart, string) {
+	var parts []llminterface.ContentPart
+
+	reasoningContent := ""
+	if msg == nil {
+		return parts, reasoningContent
+	}
+
+	for key, value := range msg.Extra {
+		if key == "" || value == nil {
+			continue
+		}
+
+		if strings.Contains(key, "reason") || strings.Contains(key, "think") {
+			switch v := value.(type) {
+			case string:
+				reasoningContent = v
+			default:
+				reasoningContent = fmt.Sprintf("%v", v)
+			}
+		}
+	}
+
+	// 处理普通内容 (Content 和 MultiContent)
+	if msg.Content != "" {
+		parts = append(parts, llminterface.ContentPart{
+			Type: llminterface.PartTypeText,
+			Text: msg.Content,
+		})
+	} else if msg.MultiContent != nil {
+		for _, mcPart := range msg.MultiContent {
+			switch mcPart.Type {
+			case schema.ChatMessagePartTypeText:
+				parts = append(parts, llminterface.ContentPart{
+					Type: llminterface.PartTypeText,
+					Text: mcPart.Text,
+				})
+			case schema.ChatMessagePartTypeImageURL:
+				if mcPart.ImageURL != nil {
+					imageDetail := llminterface.ImageDetailAuto // Default
+					if mcPart.ImageURL.Detail != "" {
+						switch mcPart.ImageURL.Detail {
+						case schema.ImageURLDetailLow:
+							imageDetail = llminterface.ImageDetailLow
+						case schema.ImageURLDetailHigh:
+							imageDetail = llminterface.ImageDetailHigh
+						case schema.ImageURLDetailAuto:
+							imageDetail = llminterface.ImageDetailAuto
+						default:
+							slog.Warn("Unknown eino ImageURLDetail, defaulting to auto", "detail", mcPart.ImageURL.Detail)
+						}
+					}
+					parts = append(parts, llminterface.ContentPart{
+						Type: llminterface.PartTypeImageURL,
+						ImageURL: Some(llminterface.ImageURLContent{
+							URL:    mcPart.ImageURL.URL,
+							Detail: Some(imageDetail),
+						}),
+					})
+				}
+			default:
+				slog.Warn("Unsupported eino.ChatMessagePartType in MultiContent.", "type", mcPart.Type)
+			}
+		}
+	}
+
+	return parts, reasoningContent
+}

--- a/pkg/reactagent/agent.go
+++ b/pkg/reactagent/agent.go
@@ -174,8 +174,8 @@ func (a *Agent) Run(ctx context.Context, userInput, conversationID string) (<-ch
 			// 记录工具调用的顺序
 			toolCallOrder := make([]string, 0)
 			// 记录当前正在组装参数的工具调用ID（如果在处理参数流）
-			var currentToolCallID string
-			var finishReason Option[string]
+			currentToolCallID := ""
+			finishReason := None[string]()
 
 			// 处理 LLM 输出流
 			for chunk := range llmOutputChan {
@@ -192,6 +192,13 @@ func (a *Agent) Run(ctx context.Context, userInput, conversationID string) (<-ch
 
 				if chunk.FinishReason.IsSome() {
 					finishReason = chunk.FinishReason
+				}
+
+				if chunk.Reasoning.IsSome() {
+					outputChan <- AgentOutputChunk{
+						Type:           AgentChunkTypeReasoning,
+						ThoughtContent: chunk.Reasoning.Unwrap(),
+					}
 				}
 
 				// 处理内容部分
@@ -463,6 +470,8 @@ type AgentOutputChunk struct {
 type AgentOutputChunkType string
 
 const (
+	// AgentChunkTypeReasoning 推理内容
+	AgentChunkTypeReasoning AgentOutputChunkType = "reasoning"
 	// AgentChunkTypeText 纯文本输出
 	AgentChunkTypeText AgentOutputChunkType = "text"
 	// AgentChunkTypeToolStart 工具开始执行的信号

--- a/pkg/reactagent/agent_without_tool_call.go
+++ b/pkg/reactagent/agent_without_tool_call.go
@@ -1,0 +1,366 @@
+package reactagent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/m4n5ter/another-me/pkg/llminterface"
+	. "github.com/m4n5ter/another-me/pkg/option"
+	"github.com/m4n5ter/another-me/pkg/toolcore"
+)
+
+// TextFormatParser 定义了如何从模型返回的文本中提取工具调用的接口
+type TextFormatParser interface {
+	// ParseToolCalls 从文本中解析出工具调用请求
+	// 返回解析出的工具调用列表和解析后的剩余文本
+	ParseToolCalls(text string) ([]llminterface.ToolCall, string)
+}
+
+// TextBasedAgent 表示一个基于文本格式的 ReAct 智能体，不依赖 function call 能力
+type TextBasedAgent struct {
+	llmAdapter       llminterface.ChatAdapter
+	toolRegistry     *toolcore.Registry
+	logger           *slog.Logger
+	maxIterations    int
+	systemPrompt     Option[llminterface.InputMessage]
+	textFormatParser TextFormatParser
+}
+
+// TextBasedAgentBuilder 是用于构建 TextBasedAgent 的构建器
+type TextBasedAgentBuilder struct {
+	llmAdapter       llminterface.ChatAdapter
+	toolRegistry     *toolcore.Registry
+	logger           *slog.Logger
+	maxIterations    int
+	systemPrompt     Option[string]
+	textFormatParser TextFormatParser
+}
+
+// NewTextBasedAgentBuilder 创建一个新的 TextBasedAgentBuilder 实例
+func NewTextBasedAgentBuilder() *TextBasedAgentBuilder {
+	return &TextBasedAgentBuilder{
+		maxIterations: 10, // 默认最大迭代次数
+	}
+}
+
+// WithLLMAdapter 设置 LLM 适配器
+func (b *TextBasedAgentBuilder) WithLLMAdapter(adapter llminterface.ChatAdapter) *TextBasedAgentBuilder {
+	b.llmAdapter = adapter
+	return b
+}
+
+// WithToolRegistry 设置工具注册表
+func (b *TextBasedAgentBuilder) WithToolRegistry(registry *toolcore.Registry) *TextBasedAgentBuilder {
+	b.toolRegistry = registry
+	return b
+}
+
+// WithLogger 设置日志记录器
+func (b *TextBasedAgentBuilder) WithLogger(logger *slog.Logger) *TextBasedAgentBuilder {
+	b.logger = logger
+	return b
+}
+
+// WithMaxIterations 设置最大迭代次数
+func (b *TextBasedAgentBuilder) WithMaxIterations(maxIter int) *TextBasedAgentBuilder {
+	if maxIter > 0 {
+		b.maxIterations = maxIter
+	}
+	return b
+}
+
+// WithSystemPrompt 设置系统提示
+func (b *TextBasedAgentBuilder) WithSystemPrompt(prompt string) *TextBasedAgentBuilder {
+	b.systemPrompt = Some(prompt)
+	return b
+}
+
+// WithTextFormatParser 设置文本格式解析器
+func (b *TextBasedAgentBuilder) WithTextFormatParser(parser TextFormatParser) *TextBasedAgentBuilder {
+	b.textFormatParser = parser
+	return b
+}
+
+// Build 构建并返回一个 TextBasedAgent 实例
+func (b *TextBasedAgentBuilder) Build() (*TextBasedAgent, error) {
+	if b.llmAdapter == nil {
+		return nil, fmt.Errorf("LLMAdapter 不能为空")
+	}
+	if b.toolRegistry == nil {
+		return nil, fmt.Errorf("ToolRegistry 不能为空")
+	}
+	if b.textFormatParser == nil {
+		return nil, fmt.Errorf("TextFormatParser 不能为空")
+	}
+
+	logger := b.logger
+	if logger == nil {
+		logger = slog.Default().WithGroup("text_based_react_agent")
+	}
+
+	// 系统提示
+	var sysPromptOpt Option[llminterface.InputMessage]
+	if b.systemPrompt.IsSome() {
+		sysPromptOpt = Some(llminterface.InputMessage{
+			Role: llminterface.RoleSystem,
+			Content: []llminterface.ContentPart{
+				{
+					Type: llminterface.PartTypeText,
+					Text: b.systemPrompt.Unwrap(),
+				},
+			},
+		})
+	}
+
+	return &TextBasedAgent{
+		llmAdapter:       b.llmAdapter,
+		toolRegistry:     b.toolRegistry,
+		logger:           logger,
+		maxIterations:    b.maxIterations,
+		systemPrompt:     sysPromptOpt,
+		textFormatParser: b.textFormatParser,
+	}, nil
+}
+
+// Run 方法执行基于文本的 ReAct 代理的核心逻辑
+// 它接收初始用户输入，并返回一个用于流式输出的只读通道
+func (a *TextBasedAgent) Run(ctx context.Context, userInput, conversationID string) (<-chan AgentOutputChunk, error) {
+	a.logger.Info("Text-based ReAct Agent Run started", "conversationID", conversationID, "userInput", userInput)
+
+	// 创建输出通道，用于流式传输 AgentOutputChunk
+	outputChan := make(chan AgentOutputChunk, 100)
+
+	// 启动一个 goroutine 执行 ReAct 循环，并通过 outputChan 流式传输结果
+	go func() {
+		defer close(outputChan) // 确保在函数退出时关闭通道
+
+		messages := make([]llminterface.InputMessage, 0)
+
+		// 添加系统提示（如果存在）
+		if a.systemPrompt.IsSome() {
+			messages = append(messages, a.systemPrompt.Unwrap())
+			a.logger.Debug("System prompt added to messages")
+		}
+
+		// 添加用户初始输入
+		userMessage := llminterface.InputMessage{
+			Role: llminterface.RoleUser,
+			Content: []llminterface.ContentPart{
+				{
+					Type: llminterface.PartTypeText,
+					Text: userInput,
+				},
+			},
+		}
+		messages = append(messages, userMessage)
+		a.logger.Debug("User input added to messages", "userInput", userInput)
+
+		var lastResponseText string
+
+		// ReAct 循环
+		for i := range a.maxIterations {
+			a.logger.Info("Iteration start", "iteration", i+1, "conversationID", conversationID)
+
+			chatInput := llminterface.ChatInput{
+				Messages:       messages,
+				ConversationID: conversationID,
+			}
+
+			// 调用 LLM
+			llmOutputChan, err := a.llmAdapter.Chat(ctx, chatInput)
+			if err != nil {
+				a.logger.Error("LLM Chat returned an initial error", "error", err, "conversationID", conversationID)
+				outputChan <- AgentOutputChunk{
+					Type:   AgentChunkTypeError,
+					Error:  fmt.Sprintf("LLM Chat 初始错误: %v", err),
+					IsLast: true,
+				}
+				return
+			}
+
+			// 用于聚合 LLM 响应的变量
+			llmThinks := ""
+
+			// 处理 LLM 输出流
+			for chunk := range llmOutputChan {
+				// 错误处理
+				if chunk.Error != nil {
+					a.logger.Error("Error in LLM stream chunk", "error", chunk.Error, "conversationID", conversationID)
+					outputChan <- AgentOutputChunk{
+						Type:   AgentChunkTypeError,
+						Error:  fmt.Sprintf("LLM 流处理错误: %v", chunk.Error),
+						IsLast: true,
+					}
+					return
+				}
+
+				if chunk.Reasoning.IsSome() {
+					outputChan <- AgentOutputChunk{
+						Type:           AgentChunkTypeReasoning,
+						ThoughtContent: chunk.Reasoning.Unwrap(),
+					}
+				}
+
+				// 处理内容部分
+				for _, part := range chunk.ContentParts {
+					// 处理文本部分 - 流式传输到 outputChan 并累积内部状态
+					if part.Type == llminterface.PartTypeText {
+						// 流式输出文本
+						outputChan <- AgentOutputChunk{
+							Type:      AgentChunkTypeText,
+							TextDelta: part.Text,
+						}
+
+						// 累积文本，用于内部使用
+						llmThinks += part.Text
+					}
+				}
+			}
+
+			// 发送完整的思考内容
+			if llmThinks != "" {
+				outputChan <- AgentOutputChunk{
+					Type:           AgentChunkTypeThought,
+					ThoughtContent: llmThinks,
+				}
+			}
+
+			lastResponseText = llmThinks // 保存最后一次LLM的文本输出，以备没有工具调用时作为最终结果
+
+			// 解析LLM响应中的工具调用
+			toolCalls, remainingText := a.textFormatParser.ParseToolCalls(llmThinks)
+
+			// 如果没有工具调用，结束循环并返回最终响应
+			if len(toolCalls) == 0 {
+				a.logger.Info("No tool calls parsed, returning final response", "conversationID", conversationID)
+				outputChan <- AgentOutputChunk{
+					Type:          AgentChunkTypeFinish,
+					FinalResponse: remainingText,
+					IsLast:        true,
+				}
+				return
+			}
+
+			// 将LLM的完整回复添加到消息历史
+			assistantMessage := llminterface.InputMessage{
+				Role: llminterface.RoleAssistant,
+				Content: []llminterface.ContentPart{
+					{
+						Type: llminterface.PartTypeText,
+						Text: llmThinks,
+					},
+				},
+			}
+			messages = append(messages, assistantMessage)
+			a.logger.Debug("Assistant's full response added to messages", "conversationID", conversationID)
+
+			// 执行工具调用
+			for _, toolCall := range toolCalls {
+				// 发送工具开始执行的信号
+				outputChan <- AgentOutputChunk{
+					Type:          AgentChunkTypeToolStart,
+					ToolCallID:    toolCall.ID,
+					ToolName:      toolCall.Name,
+					ToolArguments: toolCall.Arguments,
+				}
+
+				a.logger.Info("Executing tool", "toolName", toolCall.Name, "toolID", toolCall.ID, "argsLength", len(toolCall.Arguments), "conversationID", conversationID)
+
+				tool, exists := a.toolRegistry.Get(toolCall.Name)
+				if !exists {
+					a.logger.Error("Tool not found in registry", "toolName", toolCall.Name, "conversationID", conversationID)
+					toolResultMessage := llminterface.InputMessage{
+						Role: llminterface.RoleUser,
+						Content: []llminterface.ContentPart{
+							{
+								Type: llminterface.PartTypeText,
+								Text: fmt.Sprintf("错误：工具 '%s' 未找到。", toolCall.Name),
+							},
+						},
+					}
+					messages = append(messages, toolResultMessage)
+
+					// 发送工具结束执行的信号（带错误）
+					outputChan <- AgentOutputChunk{
+						Type:          AgentChunkTypeToolEnd,
+						ToolCallID:    toolCall.ID,
+						ToolName:      toolCall.Name,
+						ToolArguments: toolCall.Arguments,
+						Error:         fmt.Sprintf("错误：工具 '%s' 未找到。", toolCall.Name),
+					}
+
+					continue
+				}
+
+				// 执行工具调用
+				toolOutputJSON, toolErr := tool.Call(ctx, toolCall.Arguments)
+				if toolErr != nil {
+					a.logger.Error("Tool execution failed", "toolName", toolCall.Name, "toolID", toolCall.ID, "error", toolErr, "conversationID", conversationID)
+					toolResultMessage := llminterface.InputMessage{
+						Role: llminterface.RoleUser,
+						Content: []llminterface.ContentPart{
+							{
+								Type: llminterface.PartTypeText,
+								Text: fmt.Sprintf("错误：工具 '%s' 执行失败: %s", toolCall.Name, toolErr.Error()),
+							},
+						},
+					}
+					messages = append(messages, toolResultMessage)
+
+					// 发送工具结束执行的信号（带错误）
+					outputChan <- AgentOutputChunk{
+						Type:          AgentChunkTypeToolEnd,
+						ToolCallID:    toolCall.ID,
+						ToolName:      toolCall.Name,
+						ToolArguments: toolCall.Arguments,
+						Error:         fmt.Sprintf("错误：工具 '%s' 执行失败: %s", toolCall.Name, toolErr.Error()),
+					}
+
+					continue
+				}
+
+				// 添加工具调用结果
+				toolResultMessage := llminterface.InputMessage{
+					Role: llminterface.RoleUser,
+					Content: []llminterface.ContentPart{
+						{
+							Type: llminterface.PartTypeText,
+							Text: fmt.Sprintf("工具 '%s' 执行结果:\n%s", toolCall.Name, toolOutputJSON),
+						},
+					},
+				}
+				messages = append(messages, toolResultMessage)
+				a.logger.Debug("Tool result added to messages", "toolName", toolCall.Name, "toolID", toolCall.ID, "conversationID", conversationID)
+
+				// 发送工具结束执行的信号（成功）
+				outputChan <- AgentOutputChunk{
+					Type:          AgentChunkTypeToolEnd,
+					ToolCallID:    toolCall.ID,
+					ToolName:      toolCall.Name,
+					ToolArguments: toolCall.Arguments,
+					ToolResult:    toolOutputJSON,
+				}
+			}
+		}
+
+		// 如果达到最大迭代次数
+		a.logger.Warn("Max iterations reached", "maxIterations", a.maxIterations, "conversationID", conversationID)
+		if lastResponseText != "" {
+			outputChan <- AgentOutputChunk{
+				Type:          AgentChunkTypeMaxIter,
+				FinalResponse: lastResponseText,
+				Error:         fmt.Sprintf("达到最大迭代次数 (%d)，返回最后观察到的LLM输出", a.maxIterations),
+				IsLast:        true,
+			}
+		} else {
+			outputChan <- AgentOutputChunk{
+				Type:   AgentChunkTypeMaxIter,
+				Error:  fmt.Sprintf("达到最大迭代次数 (%d) 且没有LLM的最终响应", a.maxIterations),
+				IsLast: true,
+			}
+		}
+	}()
+
+	return outputChan, nil
+}

--- a/pkg/reactagent/parsers.go
+++ b/pkg/reactagent/parsers.go
@@ -1,0 +1,241 @@
+package reactagent
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	json "github.com/json-iterator/go"
+
+	"github.com/m4n5ter/another-me/pkg/llminterface"
+)
+
+// 通用解析器实现
+
+// JSONFormatParser 解析JSON格式的工具调用
+// 期望格式: {"action": "tool_name", "action_input": {...}}
+type JSONFormatParser struct{}
+
+// ParseToolCalls 解析JSON格式的工具调用
+func (p *JSONFormatParser) ParseToolCalls(text string) ([]llminterface.ToolCall, string) {
+	// 提取所有可能的JSON对象
+	jsonRegex := regexp.MustCompile(`\{(?:[^{}]|(?:\{(?:[^{}]|(?:\{[^{}]*\}))*\}))*\}`)
+	matches := jsonRegex.FindAllString(text, -1)
+
+	var toolCalls []llminterface.ToolCall
+	for i, match := range matches {
+		var parsed struct {
+			Action      string          `json:"action"`
+			ActionInput json.RawMessage `json:"action_input"`
+		}
+
+		if err := json.Unmarshal([]byte(match), &parsed); err != nil {
+			continue
+		}
+
+		if parsed.Action != "" && len(parsed.ActionInput) > 0 {
+			toolCalls = append(toolCalls, llminterface.ToolCall{
+				ID:        fmt.Sprintf("tool-%d-%s", i, time.Now().Format("150405.000")),
+				Name:      parsed.Action,
+				Arguments: string(parsed.ActionInput),
+			})
+
+			// 从文本中移除已处理的JSON
+			text = strings.Replace(text, match, "", 1)
+		}
+	}
+
+	return toolCalls, strings.TrimSpace(text)
+}
+
+// MarkdownFormatParser 解析Markdown代码块格式的工具调用
+// 期望格式:
+// ```tool_name
+// JSON参数
+// ```
+type MarkdownFormatParser struct{}
+
+// ParseToolCalls 解析Markdown代码块格式的工具调用
+func (p *MarkdownFormatParser) ParseToolCalls(text string) ([]llminterface.ToolCall, string) {
+	// 提取Markdown代码块 ```tool_name ... ```
+	mdRegex := regexp.MustCompile("```([a-zA-Z0-9_-]+)\\s*\\n([\\s\\S]*?)```")
+	matches := mdRegex.FindAllStringSubmatch(text, -1)
+
+	var toolCalls []llminterface.ToolCall
+	for i, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+
+		toolName := strings.TrimSpace(match[1])
+		arguments := strings.TrimSpace(match[2])
+
+		if toolName != "" && arguments != "" {
+			toolCalls = append(toolCalls, llminterface.ToolCall{
+				ID:        fmt.Sprintf("tool-%d-%s", i, time.Now().Format("150405.000")),
+				Name:      toolName,
+				Arguments: arguments,
+			})
+
+			// 从文本中移除已处理的代码块
+			text = strings.Replace(text, match[0], "", 1)
+		}
+	}
+
+	return toolCalls, strings.TrimSpace(text)
+}
+
+// PredefinedPatternParser 基于预定义格式解析工具调用
+// 格式例如：
+// "工具: tool_name
+// 参数: {...}"
+type PredefinedPatternParser struct {
+	// 工具调用开始模式
+	StartPattern string
+	// 参数开始模式
+	ArgPattern string
+}
+
+// ParseToolCalls 解析预定义模式的工具调用
+func (p *PredefinedPatternParser) ParseToolCalls(text string) ([]llminterface.ToolCall, string) {
+	startPattern := p.StartPattern
+	if startPattern == "" {
+		startPattern = "工具:"
+	}
+
+	argPattern := p.ArgPattern
+	if argPattern == "" {
+		argPattern = "参数:"
+	}
+
+	// 构建正则表达式
+	pattern := fmt.Sprintf("%s\\s*([a-zA-Z0-9_-]+)\\s*(?:\\n|\\r\\n?)%s\\s*([\\s\\S]*?)(?:(?:\\n|\\r\\n?)(?:%s|$)|$)",
+		regexp.QuoteMeta(startPattern),
+		regexp.QuoteMeta(argPattern),
+		regexp.QuoteMeta(startPattern))
+
+	regex := regexp.MustCompile(pattern)
+	matches := regex.FindAllStringSubmatch(text, -1)
+
+	var toolCalls []llminterface.ToolCall
+	for i, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+
+		toolName := strings.TrimSpace(match[1])
+		arguments := strings.TrimSpace(match[2])
+
+		if toolName != "" {
+			toolCalls = append(toolCalls, llminterface.ToolCall{
+				ID:        fmt.Sprintf("tool-%d-%s", i, time.Now().Format("150405.000")),
+				Name:      toolName,
+				Arguments: arguments,
+			})
+
+			// 从文本中移除已处理的匹配
+			text = strings.Replace(text, match[0], "", 1)
+		}
+	}
+
+	return toolCalls, strings.TrimSpace(text)
+}
+
+// GuiAgentFormatParser 解析类似GUI Agent格式的工具调用
+// 期望格式:
+// Thought: ...
+// Action: action_name(arg1="value1", arg2="value2")
+type GuiAgentFormatParser struct{}
+
+// ParseToolCalls 解析GUI Agent格式的工具调用
+func (p *GuiAgentFormatParser) ParseToolCalls(text string) ([]llminterface.ToolCall, string) {
+	// 提取GUI Agent格式的工具调用
+	actionRegex := regexp.MustCompile(`Action:?\s*([a-zA-Z0-9_-]+)\(([^)]*)\)`)
+	matches := actionRegex.FindAllStringSubmatch(text, -1)
+
+	var toolCalls []llminterface.ToolCall
+	for i, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+
+		toolName := strings.TrimSpace(match[1])
+		argStr := strings.TrimSpace(match[2])
+
+		// 将参数转换为JSON格式
+		args := make(map[string]any)
+
+		// 提取key="value"格式的参数
+		argPairs := regexp.MustCompile(`([a-zA-Z0-9_-]+)\s*=\s*"([^"]*)"`)
+		argMatches := argPairs.FindAllStringSubmatch(argStr, -1)
+		for _, argMatch := range argMatches {
+			if len(argMatch) >= 3 {
+				key := argMatch[1]
+				value := argMatch[2]
+				args[key] = value
+			}
+		}
+
+		// 提取key=[x1, y1, x2, y2]格式的参数
+		boxRegex := regexp.MustCompile(`([a-zA-Z0-9_-]+)\s*=\s*\[([^\]]*)\]`)
+		boxMatches := boxRegex.FindAllStringSubmatch(argStr, -1)
+		for _, boxMatch := range boxMatches {
+			if len(boxMatch) >= 3 {
+				key := boxMatch[1]
+				valueStr := boxMatch[2]
+
+				// 解析数组值
+				valueParts := strings.Split(valueStr, ",")
+				var values []any
+				for _, part := range valueParts {
+					part = strings.TrimSpace(part)
+					// 尝试解析为数字
+					if num, err := strconv.ParseInt(part, 10, 64); err == nil {
+						values = append(values, num)
+					} else if fnum, err := strconv.ParseFloat(part, 64); err == nil {
+						values = append(values, fnum)
+					} else {
+						// 作为字符串处理
+						values = append(values, part)
+					}
+				}
+				args[key] = values
+			}
+		}
+
+		// 将参数转换为JSON字符串
+		argsJSON, err := json.Marshal(args)
+		if err != nil {
+			continue
+		}
+
+		if toolName != "" {
+			toolCalls = append(toolCalls, llminterface.ToolCall{
+				ID:        fmt.Sprintf("tool-%d-%s", i, time.Now().Format("150405.000")),
+				Name:      toolName,
+				Arguments: string(argsJSON),
+			})
+		}
+	}
+
+	// 如果没有工具调用，保留整个文本
+	if len(toolCalls) == 0 {
+		return nil, text
+	}
+
+	// 提取思考部分
+	thoughtRegex := regexp.MustCompile(`Thought:?\s*([\s\S]*?)(?:Action:|$)`)
+	thoughtMatch := thoughtRegex.FindStringSubmatch(text)
+	if len(thoughtMatch) >= 2 {
+		return toolCalls, strings.TrimSpace(thoughtMatch[1])
+	}
+
+	// 如果没有明确的思考部分，移除Action部分后返回剩余文本
+	for _, match := range matches {
+		text = strings.Replace(text, match[0], "", 1)
+	}
+
+	return toolCalls, strings.TrimSpace(text)
+}


### PR DESCRIPTION
- 在 examples/text_agent/main.go 中实现了一个不依赖于 function call 能力的 ReAct Agent，支持流式输出和多种文本格式解析器。
- 新增 examples/text_agent/README.md，详细说明了示例的功能特点、使用方法和常见问题解决方案。
- 在 pkg/reactagent 中新增多个解析器，支持 JSON、Markdown 和预定义模式的工具调用解析。
- 更新了 llminterface 和 reactagent 的相关结构体，增强了推理内容的处理能力。