### PR TITLE
fix: 更新日志记录方式，替换标准库 log 为 log/slog

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,8 +117,8 @@ linters:
       rules:
         deny-log:
           deny:
-            # - pkg: "log$"
-            #   desc: "禁止使用标准库 log，请使用 log/slog"
+            - pkg: "log$"
+              desc: "禁止使用标准库 log，请使用 log/slog，如果需要 Fatal，请使用 slog.Error 并调用 os.Exit 或 return/panic"
             - pkg: "encoding/json"
               desc: '禁止使用标准库 encoding/json，请使用 json "github.com/json-iterator/go"'
     nestif:

--- a/examples/browser_agent/main.go
+++ b/examples/browser_agent/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 
@@ -181,12 +180,14 @@ func registerTools(registry *toolcore.Registry, i18nMgr *i18n.Manager) {
 	browserTool := browsertool.NewBrowserToolWithConfig(i18nMgr, browserConfig)
 	err := registry.Register(ctx, browserTool)
 	if err != nil {
-		log.Fatalf("注册浏览器工具失败: %v", err)
+		slog.Error("注册浏览器工具失败", "error", err)
+		os.Exit(1)
 	}
 
 	fetchTool := fetchtool.NewFetchTool(i18nMgr)
 	err = registry.Register(ctx, fetchTool)
 	if err != nil {
-		log.Fatalf("注册 Fetch 工具失败: %v", err)
+		slog.Error("注册 Fetch 工具失败", "error", err)
+		os.Exit(1)
 	}
 }

--- a/examples/react_agent/main.go
+++ b/examples/react_agent/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"time"
@@ -131,7 +130,8 @@ func registerTools(registry *toolcore.Registry, i18nMgr *i18n.Manager) {
 	fetchTool := fetchtool.NewFetchTool(i18nMgr)
 	err := registry.Register(ctx, fetchTool)
 	if err != nil {
-		log.Fatalf("Failed to register fetch tool: %v", err)
+		slog.Error("Failed to register fetch tool", "error", err)
+		os.Exit(1)
 	}
 
 	// 注册 GUI 工具
@@ -139,7 +139,8 @@ func registerTools(registry *toolcore.Registry, i18nMgr *i18n.Manager) {
 	for _, tool := range guiTools {
 		err := registry.Register(ctx, tool)
 		if err != nil {
-			log.Fatalf("Failed to register gui tool: %v", err)
+			slog.Error("Failed to register gui tool", "error", err)
+			os.Exit(1)
 		}
 	}
 

--- a/pkg/i18n/init.go
+++ b/pkg/i18n/init.go
@@ -2,8 +2,8 @@ package i18n
 
 import (
 	"io/fs"
-	"log"
 	"log/slog"
+	"os"
 )
 
 // GlobalManager 是一个全局的 Manager 实例，方便在应用各处直接调用。
@@ -17,7 +17,7 @@ func init() {
 	actualLocalesFS, errSub := fs.Sub(localeFS, "locales")
 	if errSub != nil {
 		slog.Error("i18n: 初始化全局 GlobalManager 失败，无法获取 locales 子文件系统", "错误", errSub)
-		log.Fatalf("i18n: 致命错误：无法从内嵌文件系统获取 locales 子文件系统: %v", errSub)
+		os.Exit(1)
 	}
 
 	GlobalManager, err = NewManager(actualLocalesFS, "en")
@@ -25,7 +25,7 @@ func init() {
 		// slog 通常用于应用级别的日志，但在 init 中，如果 slog 本身还未完全配置，
 		// 或者这是一个关键到无法启动的错误，直接使用标准 log.Fatalf 更为稳妥。
 		slog.Error("i18n: 初始化全局 GlobalManager 失败", "错误", err)
-		log.Fatalf("i18n: 致命错误：无法初始化全局 i18n 管理器: %v", err)
+		os.Exit(1)
 	}
 	// 全局 Manager 初始化成功，NewManager 内部已有日志记录。
 }


### PR DESCRIPTION
- 修改多个代理的 main.go 文件，使用 log/slog 进行日志记录，提升日志管理能力
- 更新 .golangci.yaml 配置，禁止使用标准库 log，建议使用 log/slog
- 在 i18n 初始化中处理致命错误时，直接退出程序以确保稳定性