### PR TITLE
feat(mindscape): 添加 Memory 客户端并重构 Sentinel 客户端

### DIFF
--- a/internal/mindscape/client.go
+++ b/internal/mindscape/client.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/m4n5ter/another-me/internal/mindscape/memory"
 	"github.com/m4n5ter/another-me/internal/mindscape/sentinel"
+
+	. "github.com/m4n5ter/another-me/pkg/option"
 )
 
 // Config 是 mindscape 的配置
@@ -18,18 +21,24 @@ type Config struct {
 // Client 是 mindscape 的客户端
 type Client struct {
 	Sentinel *sentinel.Sentinel
+	Memory   *memory.Memory
 }
 
 // NewClient 创建一个 mindscape 客户端
 func NewClient(config Config) *Client {
-	httpClient := &http.Client{
+	httpClient := Some(http.Client{
 		Timeout: 10 * time.Second,
-	}
+	})
 
 	scheme := "http"
 	if config.TLS {
 		scheme = "https"
 	}
 
-	return &Client{Sentinel: sentinel.NewSentinel(httpClient, fmt.Sprintf("%s://%s:%d", scheme, config.Host, config.Port))}
+	baseURL := fmt.Sprintf("%s://%s:%d", scheme, config.Host, config.Port)
+
+	return &Client{
+		Sentinel: sentinel.NewSentinel(httpClient, baseURL),
+		Memory:   memory.NewMemory(httpClient, baseURL),
+	}
 }

--- a/internal/mindscape/memory/memory.go
+++ b/internal/mindscape/memory/memory.go
@@ -14,7 +14,7 @@ import (
 
 // Memory 是 mindscape 的 memory 客户端
 type Memory struct {
-	client     *http.Client
+	client     *common.HTTPClient
 	baseURL    string
 	pathPrefix string
 }
@@ -27,7 +27,7 @@ func NewMemory(client Option[http.Client], baseURL string) *Memory {
 		})
 	}
 
-	return &Memory{client: client.UnwrapAsPtr(), baseURL: baseURL, pathPrefix: "/api/v1/memory"}
+	return &Memory{client: common.NewHTTPClient(client.UnwrapAsPtr()), baseURL: baseURL, pathPrefix: "/api/v1/memory"}
 }
 
 // StoreMemoryFragment 存储记忆片段
@@ -36,7 +36,7 @@ func (m *Memory) StoreMemoryFragment(ctx context.Context, storeReq memoryDTO.Sto
 	headers.Set("Content-Type", "application/json")
 
 	var fragmentResp memoryDTO.MemoryFragmentResponse
-	if err := common.HTTPPost(ctx, fmt.Sprintf("%s%s/fragments", m.baseURL, m.pathPrefix), Some(headers), storeReq, &fragmentResp, "store memory fragment"); err != nil {
+	if err := m.client.HTTPPost(ctx, fmt.Sprintf("%s%s/fragments", m.baseURL, m.pathPrefix), Some(headers), storeReq, &fragmentResp, "store memory fragment"); err != nil {
 		return nil, fmt.Errorf("failed to store memory fragment: %w", err)
 	}
 	return &fragmentResp, nil
@@ -48,7 +48,7 @@ func (m *Memory) RecallMemory(ctx context.Context, recallReq memoryDTO.RecallMem
 	headers.Set("Content-Type", "application/json")
 
 	var recallResp memoryDTO.RecallMemoriesResponse
-	if err := common.HTTPPost(ctx, fmt.Sprintf("%s%s/recall", m.baseURL, m.pathPrefix), Some(headers), recallReq, &recallResp, "recall memories"); err != nil {
+	if err := m.client.HTTPPost(ctx, fmt.Sprintf("%s%s/recall", m.baseURL, m.pathPrefix), Some(headers), recallReq, &recallResp, "recall memories"); err != nil {
 		return nil, fmt.Errorf("failed to recall memories: %w", err)
 	}
 	return &recallResp, nil

--- a/internal/mindscape/memory/memory.go
+++ b/internal/mindscape/memory/memory.go
@@ -1,0 +1,55 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	memoryDTO "github.com/m4n5ter/mindscape/memory/api/dto"
+
+	"github.com/m4n5ter/another-me/pkg/common"
+	. "github.com/m4n5ter/another-me/pkg/option"
+)
+
+// Memory 是 mindscape 的 memory 客户端
+type Memory struct {
+	client     *http.Client
+	baseURL    string
+	pathPrefix string
+}
+
+// NewMemory 创建一个 mindscape 的 memory 客户端
+func NewMemory(client Option[http.Client], baseURL string) *Memory {
+	if client.IsNone() {
+		client = Some(http.Client{
+			Timeout: 30 * time.Second,
+		})
+	}
+
+	return &Memory{client: client.UnwrapAsPtr(), baseURL: baseURL, pathPrefix: "/api/v1/memory"}
+}
+
+// StoreMemoryFragment 存储记忆片段
+func (m *Memory) StoreMemoryFragment(ctx context.Context, storeReq memoryDTO.StoreMemoryRequest) (*memoryDTO.MemoryFragmentResponse, error) {
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+
+	var fragmentResp memoryDTO.MemoryFragmentResponse
+	if err := common.HTTPPost(ctx, fmt.Sprintf("%s%s/fragments", m.baseURL, m.pathPrefix), Some(headers), storeReq, &fragmentResp, "store memory fragment"); err != nil {
+		return nil, fmt.Errorf("failed to store memory fragment: %w", err)
+	}
+	return &fragmentResp, nil
+}
+
+// RecallMemory 回忆记忆
+func (m *Memory) RecallMemory(ctx context.Context, recallReq memoryDTO.RecallMemoriesRequest) (*memoryDTO.RecallMemoriesResponse, error) {
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+
+	var recallResp memoryDTO.RecallMemoriesResponse
+	if err := common.HTTPPost(ctx, fmt.Sprintf("%s%s/recall", m.baseURL, m.pathPrefix), Some(headers), recallReq, &recallResp, "recall memories"); err != nil {
+		return nil, fmt.Errorf("failed to recall memories: %w", err)
+	}
+	return &recallResp, nil
+}

--- a/internal/mindscape/sentinel/sentinel.go
+++ b/internal/mindscape/sentinel/sentinel.go
@@ -1,14 +1,17 @@
 package sentinel
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/google/uuid"
-	json "github.com/json-iterator/go"
 	sentinelDTO "github.com/m4n5ter/mindscape/sentinel/api/dto"
+
+	"github.com/m4n5ter/another-me/pkg/common"
+	. "github.com/m4n5ter/another-me/pkg/option"
 )
 
 // Sentinel 客户端
@@ -19,38 +22,24 @@ type Sentinel struct {
 }
 
 // NewSentinel 创建一个 Sentinel 客户端
-func NewSentinel(client *http.Client, baseURL string) *Sentinel {
-	return &Sentinel{client: client, baseURL: baseURL, pathPrefix: "/api/v1/sentinel"}
+func NewSentinel(client Option[http.Client], baseURL string) *Sentinel {
+	if client.IsNone() {
+		client = Some(http.Client{
+			Timeout: 30 * time.Second,
+		})
+	}
+
+	return &Sentinel{client: client.UnwrapAsPtr(), baseURL: baseURL, pathPrefix: "/api/v1/sentinel"}
 }
 
 // CreateTask 创建一个任务
 func (s *Sentinel) CreateTask(ctx context.Context, createReq sentinelDTO.CreateTaskRequest) (*sentinelDTO.TaskResponse, error) {
-	fullURL := fmt.Sprintf("%s%s/tasks", s.baseURL, s.pathPrefix)
-	jsonBody, err := json.Marshal(createReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal create request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewBuffer(jsonBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to create task: %s", resp.Status)
-	}
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
 
 	var taskResp sentinelDTO.TaskResponse
-	if err := json.NewDecoder(resp.Body).Decode(&taskResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if err := common.HTTPPost(ctx, fmt.Sprintf("%s%s/tasks", s.baseURL, s.pathPrefix), Some(headers), createReq, &taskResp, "create task"); err != nil {
+		return nil, fmt.Errorf("failed to create task: %w", err)
 	}
 
 	return &taskResp, nil
@@ -58,28 +47,12 @@ func (s *Sentinel) CreateTask(ctx context.Context, createReq sentinelDTO.CreateT
 
 // GetTask 获取一个任务
 func (s *Sentinel) GetTask(ctx context.Context, taskID uuid.UUID) (*sentinelDTO.TaskResponse, error) {
-	fullURL := fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to do request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get task: %s", resp.Status)
-	}
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
 
 	var taskResp sentinelDTO.TaskResponse
-	if err := json.NewDecoder(resp.Body).Decode(&taskResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+	if err := common.HTTPGet(ctx, fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID), Some(headers), None[url.Values](), &taskResp, "get task"); err != nil {
+		return nil, fmt.Errorf("failed to get task: %w", err)
 	}
 
 	return &taskResp, nil
@@ -87,23 +60,11 @@ func (s *Sentinel) GetTask(ctx context.Context, taskID uuid.UUID) (*sentinelDTO.
 
 // DeleteTask 删除一个任务
 func (s *Sentinel) DeleteTask(ctx context.Context, taskID uuid.UUID) error {
-	fullURL := fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID)
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fullURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to do request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to delete task: %s", resp.Status)
+	if err := common.HTTPDelete(ctx, fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID), Some(headers), nil, "delete task"); err != nil {
+		return fmt.Errorf("failed to delete task: %w", err)
 	}
 
 	return nil
@@ -111,23 +72,11 @@ func (s *Sentinel) DeleteTask(ctx context.Context, taskID uuid.UUID) error {
 
 // HealthCheck 检查 Sentinel 是否健康
 func (s *Sentinel) HealthCheck(ctx context.Context) error {
-	fullURL := fmt.Sprintf("%s%s/health", s.baseURL, s.pathPrefix)
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to do request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to health check: %s", resp.Status)
+	if err := common.HTTPGet(ctx, fmt.Sprintf("%s%s/health", s.baseURL, s.pathPrefix), Some(headers), None[url.Values](), nil, "health check"); err != nil {
+		return fmt.Errorf("failed to health check: %w", err)
 	}
 
 	return nil

--- a/internal/mindscape/sentinel/sentinel.go
+++ b/internal/mindscape/sentinel/sentinel.go
@@ -16,7 +16,7 @@ import (
 
 // Sentinel 客户端
 type Sentinel struct {
-	client     *http.Client
+	client     *common.HTTPClient
 	baseURL    string
 	pathPrefix string
 }
@@ -29,7 +29,7 @@ func NewSentinel(client Option[http.Client], baseURL string) *Sentinel {
 		})
 	}
 
-	return &Sentinel{client: client.UnwrapAsPtr(), baseURL: baseURL, pathPrefix: "/api/v1/sentinel"}
+	return &Sentinel{client: common.NewHTTPClient(client.UnwrapAsPtr()), baseURL: baseURL, pathPrefix: "/api/v1/sentinel"}
 }
 
 // CreateTask 创建一个任务
@@ -38,7 +38,7 @@ func (s *Sentinel) CreateTask(ctx context.Context, createReq sentinelDTO.CreateT
 	headers.Set("Content-Type", "application/json")
 
 	var taskResp sentinelDTO.TaskResponse
-	if err := common.HTTPPost(ctx, fmt.Sprintf("%s%s/tasks", s.baseURL, s.pathPrefix), Some(headers), createReq, &taskResp, "create task"); err != nil {
+	if err := s.client.HTTPPost(ctx, fmt.Sprintf("%s%s/tasks", s.baseURL, s.pathPrefix), Some(headers), createReq, &taskResp, "create task"); err != nil {
 		return nil, fmt.Errorf("failed to create task: %w", err)
 	}
 
@@ -51,7 +51,7 @@ func (s *Sentinel) GetTask(ctx context.Context, taskID uuid.UUID) (*sentinelDTO.
 	headers.Set("Content-Type", "application/json")
 
 	var taskResp sentinelDTO.TaskResponse
-	if err := common.HTTPGet(ctx, fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID), Some(headers), None[url.Values](), &taskResp, "get task"); err != nil {
+	if err := s.client.HTTPGet(ctx, fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID), Some(headers), None[url.Values](), &taskResp, "get task"); err != nil {
 		return nil, fmt.Errorf("failed to get task: %w", err)
 	}
 
@@ -63,7 +63,7 @@ func (s *Sentinel) DeleteTask(ctx context.Context, taskID uuid.UUID) error {
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 
-	if err := common.HTTPDelete(ctx, fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID), Some(headers), nil, "delete task"); err != nil {
+	if err := s.client.HTTPDelete(ctx, fmt.Sprintf("%s%s/tasks/%s", s.baseURL, s.pathPrefix, taskID), Some(headers), nil, "delete task"); err != nil {
 		return fmt.Errorf("failed to delete task: %w", err)
 	}
 
@@ -75,7 +75,7 @@ func (s *Sentinel) HealthCheck(ctx context.Context) error {
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 
-	if err := common.HTTPGet(ctx, fmt.Sprintf("%s%s/health", s.baseURL, s.pathPrefix), Some(headers), None[url.Values](), nil, "health check"); err != nil {
+	if err := s.client.HTTPGet(ctx, fmt.Sprintf("%s%s/health", s.baseURL, s.pathPrefix), Some(headers), None[url.Values](), nil, "health check"); err != nil {
 		return fmt.Errorf("failed to health check: %w", err)
 	}
 

--- a/pkg/common/http_client.go
+++ b/pkg/common/http_client.go
@@ -3,7 +3,9 @@ package common
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -12,6 +14,18 @@ import (
 
 	. "github.com/m4n5ter/another-me/pkg/option"
 )
+
+// HTTPClient 是 HTTP 客户端
+type HTTPClient struct {
+	client *http.Client
+}
+
+// NewHTTPClient 创建一个 HTTP 客户端
+func NewHTTPClient(client *http.Client) *HTTPClient {
+	return &HTTPClient{
+		client: client,
+	}
+}
 
 // HTTPPost 发送 POST 请求
 //
@@ -24,7 +38,7 @@ import (
 // 返回错误信息
 //
 //nolint:dupl // 与 HTTPPut 的实现类似
-func HTTPPost(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
+func (h *HTTPClient) HTTPPost(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
 	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal %s request: %w", operation, err)
@@ -43,7 +57,7 @@ func HTTPPost(ctx context.Context, endpoint string, headers Option[http.Header],
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to do request: %w", err)
 	}
@@ -53,8 +67,10 @@ func HTTPPost(ctx context.Context, endpoint string, headers Option[http.Header],
 		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
 	}
 
 	return nil
@@ -69,7 +85,7 @@ func HTTPPost(ctx context.Context, endpoint string, headers Option[http.Header],
 //	operation: 操作的名称
 //
 // 返回错误信息
-func HTTPPostWithForm(ctx context.Context, endpoint string, headers Option[http.Header], requestForm url.Values, responseBody any, operation string) error {
+func (h *HTTPClient) HTTPPostWithForm(ctx context.Context, endpoint string, headers Option[http.Header], requestForm url.Values, responseBody any, operation string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(requestForm.Encode()))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -85,7 +101,7 @@ func HTTPPostWithForm(ctx context.Context, endpoint string, headers Option[http.
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to do request: %w", err)
 	}
@@ -95,8 +111,10 @@ func HTTPPostWithForm(ctx context.Context, endpoint string, headers Option[http.
 		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
 	}
 
 	return nil
@@ -111,7 +129,7 @@ func HTTPPostWithForm(ctx context.Context, endpoint string, headers Option[http.
 //	operation: 操作的名称
 //
 // 返回错误信息
-func HTTPGet(ctx context.Context, endpoint string, headers Option[http.Header], queryParams Option[url.Values], responseBody any, operation string) error {
+func (h *HTTPClient) HTTPGet(ctx context.Context, endpoint string, headers Option[http.Header], queryParams Option[url.Values], responseBody any, operation string) error {
 	fullURL := endpoint
 	if queryParams.IsSome() {
 		fullURL += "?" + queryParams.Unwrap().Encode()
@@ -130,7 +148,7 @@ func HTTPGet(ctx context.Context, endpoint string, headers Option[http.Header], 
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to do request: %w", err)
 	}
@@ -140,8 +158,10 @@ func HTTPGet(ctx context.Context, endpoint string, headers Option[http.Header], 
 		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
 	}
 
 	return nil
@@ -157,7 +177,7 @@ func HTTPGet(ctx context.Context, endpoint string, headers Option[http.Header], 
 // 返回错误信息
 //
 //nolint:dupl // 与 HTTPGet 的实现类似
-func HTTPDelete(ctx context.Context, endpoint string, headers Option[http.Header], responseBody any, operation string) error {
+func (h *HTTPClient) HTTPDelete(ctx context.Context, endpoint string, headers Option[http.Header], responseBody any, operation string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -171,7 +191,7 @@ func HTTPDelete(ctx context.Context, endpoint string, headers Option[http.Header
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to do request: %w", err)
 	}
@@ -181,8 +201,10 @@ func HTTPDelete(ctx context.Context, endpoint string, headers Option[http.Header
 		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
 	}
 
 	return nil
@@ -199,7 +221,7 @@ func HTTPDelete(ctx context.Context, endpoint string, headers Option[http.Header
 // 返回错误信息
 //
 //nolint:dupl // 与 HTTPPost 的实现类似
-func HTTPPut(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
+func (h *HTTPClient) HTTPPut(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
 	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal %s request: %w", operation, err)
@@ -218,7 +240,7 @@ func HTTPPut(ctx context.Context, endpoint string, headers Option[http.Header], 
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to do request: %w", err)
 	}
@@ -228,8 +250,10 @@ func HTTPPut(ctx context.Context, endpoint string, headers Option[http.Header], 
 		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
 	}
 
 	return nil
@@ -246,7 +270,7 @@ func HTTPPut(ctx context.Context, endpoint string, headers Option[http.Header], 
 // 返回错误信息
 //
 //nolint:dupl // 与 HTTPPut 的实现类似
-func HTTPPatch(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
+func (h *HTTPClient) HTTPPatch(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
 	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal %s request: %w", operation, err)
@@ -265,7 +289,7 @@ func HTTPPatch(ctx context.Context, endpoint string, headers Option[http.Header]
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to do request: %w", err)
 	}
@@ -275,8 +299,10 @@ func HTTPPatch(ctx context.Context, endpoint string, headers Option[http.Header]
 		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
 	}
 
 	return nil
@@ -292,7 +318,7 @@ func HTTPPatch(ctx context.Context, endpoint string, headers Option[http.Header]
 // 返回错误信息
 //
 //nolint:dupl // 与 HTTPGet 的实现类似
-func HTTPOptions(ctx context.Context, endpoint string, headers Option[http.Header], responseBody any, operation string) error {
+func (h *HTTPClient) HTTPOptions(ctx context.Context, endpoint string, headers Option[http.Header], responseBody any, operation string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodOptions, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -306,7 +332,7 @@ func HTTPOptions(ctx context.Context, endpoint string, headers Option[http.Heade
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to do request: %w", err)
 	}
@@ -316,8 +342,10 @@ func HTTPOptions(ctx context.Context, endpoint string, headers Option[http.Heade
 		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	if responseBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/common/http_client.go
+++ b/pkg/common/http_client.go
@@ -1,0 +1,324 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	json "github.com/json-iterator/go"
+
+	. "github.com/m4n5ter/another-me/pkg/option"
+)
+
+// HTTPPost 发送 POST 请求
+//
+//	endpoint: 请求的 URL
+//	headers: 请求的 headers
+//	requestBody: 请求的 body
+//	responseBody: 响应的 body
+//	operation: 操作的名称
+//
+// 返回错误信息
+//
+//nolint:dupl // 与 HTTPPut 的实现类似
+func HTTPPost(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s request: %w", operation, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers.IsSome() {
+		for key, values := range headers.Unwrap() {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+// HTTPPostWithForm 发送 POST 请求
+//
+//	endpoint: 请求的 URL
+//	headers: 请求的 headers
+//	requestForm: 请求的表单数据
+//	responseBody: 响应的 body
+//	operation: 操作的名称
+//
+// 返回错误信息
+func HTTPPostWithForm(ctx context.Context, endpoint string, headers Option[http.Header], requestForm url.Values, responseBody any, operation string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(requestForm.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers.IsSome() {
+		for key, values := range headers.Unwrap() {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+// HTTPGet 发送 GET 请求
+//
+//	endpoint: 请求的 URL
+//	headers: 请求的 headers
+//	queryParams: 请求的查询参数
+//	responseBody: 响应的 body
+//	operation: 操作的名称
+//
+// 返回错误信息
+func HTTPGet(ctx context.Context, endpoint string, headers Option[http.Header], queryParams Option[url.Values], responseBody any, operation string) error {
+	fullURL := endpoint
+	if queryParams.IsSome() {
+		fullURL += "?" + queryParams.Unwrap().Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers.IsSome() {
+		for key, values := range headers.Unwrap() {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+// HTTPDelete 发送 DELETE 请求
+//
+//	endpoint: 请求的 URL
+//	headers: 请求的 headers
+//	responseBody: 响应的 body
+//	operation: 操作的名称
+//
+// 返回错误信息
+//
+//nolint:dupl // 与 HTTPGet 的实现类似
+func HTTPDelete(ctx context.Context, endpoint string, headers Option[http.Header], responseBody any, operation string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers.IsSome() {
+		for key, values := range headers.Unwrap() {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+// HTTPPut 发送 PUT 请求
+//
+//	endpoint: 请求的 URL
+//	headers: 请求的 headers
+//	requestBody: 请求的 body
+//	responseBody: 响应的 body
+//	operation: 操作的名称
+//
+// 返回错误信息
+//
+//nolint:dupl // 与 HTTPPost 的实现类似
+func HTTPPut(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s request: %w", operation, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers.IsSome() {
+		for key, values := range headers.Unwrap() {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+// HTTPPatch 发送 PATCH 请求
+//
+//	endpoint: 请求的 URL
+//	headers: 请求的 headers
+//	requestBody: 请求的 body
+//	responseBody: 响应的 body
+//	operation: 操作的名称
+//
+// 返回错误信息
+//
+//nolint:dupl // 与 HTTPPut 的实现类似
+func HTTPPatch(ctx context.Context, endpoint string, headers Option[http.Header], requestBody, responseBody any, operation string) error {
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s request: %w", operation, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, endpoint, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers.IsSome() {
+		for key, values := range headers.Unwrap() {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+// HTTPOptions 发送 OPTIONS 请求
+//
+//	endpoint: 请求的 URL
+//	headers: 请求的 headers
+//	responseBody: 响应的 body
+//	operation: 操作的名称
+//
+// 返回错误信息
+//
+//nolint:dupl // 与 HTTPGet 的实现类似
+func HTTPOptions(ctx context.Context, endpoint string, headers Option[http.Header], responseBody any, operation string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodOptions, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headers.IsSome() {
+		for key, values := range headers.Unwrap() {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s: %s", operation, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- 新增 Memory 客户端，支持存储和回忆记忆片段
- 更新 Sentinel 客户端，重构 HTTP 请求逻辑，增强代码复用性
- 在 Mindscape 客户端中集成 Memory 客户端，提升功能完整性